### PR TITLE
Explicit name and symbol (& Sepolia support)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,8 +9,9 @@ optimizer_runs = 1000000
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 
 [rpc_endpoints]
-mainnet = "https://mainnet.infura.io/v3/${INFURA_API_KEY}"
-goerli = "https://goerli.infura.io/v3/${INFURA_API_KEY}"
+mainnet = "https://rpc.mevblocker.io/"
+goerli = "https://ethereum-goerli.publicnode.com"
 gnosischain = "https://rpc.gnosischain.com"
+sepolia = "https://ethereum-sepolia.publicnode.com"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/readme.md
+++ b/readme.md
@@ -27,17 +27,15 @@ forge build
 Run the following commands to deploy the contract in the specified network and verify it on the chain explorer.
 
 ```sh
-export INFURA_API_KEY=<your Infura key here>
 forge create --rpc-url goerli \
-    --constructor-args <address of the contract admin> <address of an address that can freely mint and burn token> \
+    --constructor-args <address of the contract admin> <address that can freely mint and burn token> <token name> <token symbol> \
     --private-key <your_private_key> \
     --etherscan-api-key <your_etherscan_api_key> \
     --verify \
     src/CowSwapTestToken.sol:CowSwapTestToken
 ```
 
-Valid parameters for `rpc-url` are `mainnet`, `goerli`, `gnosischain`.
-All networks except latter require an Infura API key.
+Valid parameters for `rpc-url` are `mainnet`, `goerli`, `gnosischain`, `sepolia`.
 You can also specify your own RPC URL.
 
 ### Code formatting

--- a/src/CowSwapTestToken.sol
+++ b/src/CowSwapTestToken.sol
@@ -13,12 +13,13 @@ import {ERC20Permit} from "lib/openzeppelin-contracts/contracts/token/ERC20/exte
 contract CowSwapTestToken is ERC20, AccessControl, ERC20Permit {
     bytes32 public constant MINTER_BURNER_ROLE =
         keccak256("MINTER_BURNER_ROLE");
-    string internal constant NAME = "CoW Swap Test Token v1";
 
     constructor(
         address admin,
-        address balanceManager
-    ) ERC20(NAME, "COWTEST1") ERC20Permit(NAME) {
+        address balanceManager,
+        string memory name,
+        string memory symbol
+    ) ERC20(name, symbol) ERC20Permit(name) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(MINTER_BURNER_ROLE, balanceManager);
     }

--- a/test/CowSwapTestToken.t.sol
+++ b/test/CowSwapTestToken.t.sol
@@ -8,9 +8,11 @@ contract CowSwapTestTokenTest is Test {
     CowSwapTestToken public token;
     address internal admin = address(0x42);
     address internal minterBurner = address(0x21);
+    string internal name = "Token name";
+    string internal symbol = "SYM";
 
     function setUp() public {
-        token = new CowSwapTestToken(admin, minterBurner);
+        token = new CowSwapTestToken(admin, minterBurner, name, symbol);
     }
 
     function testSetRole() public {
@@ -53,5 +55,13 @@ contract CowSwapTestTokenTest is Test {
         vm.prank(minterBurner);
         token.burn(user, balanceBurnt);
         assertEq(token.balanceOf(user), initialBalance - balanceBurnt);
+    }
+
+    function testName() public {
+        assertEq(token.name(), name);
+    }
+
+    function testSymbol() public {
+        assertEq(token.symbol(), symbol);
     }
 }


### PR DESCRIPTION
Adds support for explicit token symbol and name.
I deployed a few tokens on Sepolia with this, reason for which I also updated RPC urls.

### Test plan

You can check for example [this](https://sepolia.etherscan.io/token/0xe9ec8f41238a762aa31f6428b2c24982812521f1), which was deployed with the new code. Also, unit tests.

